### PR TITLE
feat(generator/vscode): add yarn as pkg manager and disable tsc

### DIFF
--- a/lib/generators/vscode/templates/settings.json.ejs
+++ b/lib/generators/vscode/templates/settings.json.ejs
@@ -1,5 +1,6 @@
 {
-<% if (yarn2) { -%>
+  "npm.packageManager": "yarn",
+  <% if (yarn2) { -%>
   // yarn berry
   "eslint.nodePath": ".yarn/sdks",
   "prettier.prettierPath": ".yarn/sdks/prettier/index.js",
@@ -10,6 +11,7 @@
 
 <% } else { -%>
 <% if (typescript) { -%>
+  "typescript.tsc.autoDetect": "off",
   "typescript.tsdk": "node_modules/typescript/lib",
 
 <% } -%>


### PR DESCRIPTION
- npm.packageManager : force vscode to run scripts with yarn
- typescript.tsc.autoDetect: disable the build with vscode. We use babel via rollup

<!-- Uncomment this if you need a testing plan
### Testing plan
- [ ] Test this
- [ ] Test that
-->
