### PR TITLE
fix: source fixall eslint only [no issue]

### DIFF
--- a/lib/generators/vscode/templates/settings.json.ejs
+++ b/lib/generators/vscode/templates/settings.json.ejs
@@ -34,7 +34,7 @@
   "editor.formatOnSave": true,
   "eslint.codeActionsOnSave.mode": "all",
   "editor.codeActionsOnSave": {
-    "source.fixAll": true,
+    "source.fixAll.eslint": true,
     "source.organizeImports": false
   },
 


### PR DESCRIPTION
### Context

if fixAll is enabled, unreachable code is deleted, even when we have a syntax error

### Solution

only enable autofix for eslint
prettier is a formatter
