### PR TITLE
feat: add bumper Sticker migrate codemod - OSE-24569

### DIFF
--- a/lib/codemods/bumper/sticker/migrate/__testfixtures__/alreadyBumper.input.js
+++ b/lib/codemods/bumper/sticker/migrate/__testfixtures__/alreadyBumper.input.js
@@ -1,0 +1,5 @@
+import { Sticker } from '@ornikar/bumper';
+
+function Example() {
+  return <Sticker label="Already" color="green" />;
+}

--- a/lib/codemods/bumper/sticker/migrate/__testfixtures__/alreadyBumper.input.js
+++ b/lib/codemods/bumper/sticker/migrate/__testfixtures__/alreadyBumper.input.js
@@ -1,5 +1,5 @@
 import { Sticker } from '@ornikar/bumper';
 
 function Example() {
-  return <Sticker label="Already" color="green" />;
+  return <Sticker label="Already" stickerColor="green" />;
 }

--- a/lib/codemods/bumper/sticker/migrate/__testfixtures__/alreadyBumper.output.js
+++ b/lib/codemods/bumper/sticker/migrate/__testfixtures__/alreadyBumper.output.js
@@ -1,0 +1,5 @@
+import { Sticker } from '@ornikar/bumper';
+
+function Example() {
+  return <Sticker label="Already" color="green" />;
+}

--- a/lib/codemods/bumper/sticker/migrate/__testfixtures__/alreadyBumper.output.js
+++ b/lib/codemods/bumper/sticker/migrate/__testfixtures__/alreadyBumper.output.js
@@ -1,5 +1,5 @@
 import { Sticker } from '@ornikar/bumper';
 
 function Example() {
-  return <Sticker label="Already" color="green" />;
+  return <Sticker label="Already" stickerColor="green" />;
 }

--- a/lib/codemods/bumper/sticker/migrate/__testfixtures__/basic.input.js
+++ b/lib/codemods/bumper/sticker/migrate/__testfixtures__/basic.input.js
@@ -1,0 +1,5 @@
+import { Sticker } from '@ornikar/kitt-universal';
+
+function Example() {
+  return <Sticker label="Active" color="green" size="medium" />;
+}

--- a/lib/codemods/bumper/sticker/migrate/__testfixtures__/basic.output.js
+++ b/lib/codemods/bumper/sticker/migrate/__testfixtures__/basic.output.js
@@ -1,0 +1,5 @@
+import { Sticker } from '@ornikar/bumper';
+
+function Example() {
+  return <Sticker label="Active" color="green" size="medium" />;
+}

--- a/lib/codemods/bumper/sticker/migrate/__testfixtures__/basic.output.js
+++ b/lib/codemods/bumper/sticker/migrate/__testfixtures__/basic.output.js
@@ -1,5 +1,5 @@
 import { Sticker } from '@ornikar/bumper';
 
 function Example() {
-  return <Sticker label="Active" color="green" size="medium" />;
+  return <Sticker label="Active" stickerColor="green" size="medium" />;
 }

--- a/lib/codemods/bumper/sticker/migrate/__testfixtures__/colorRenames.input.js
+++ b/lib/codemods/bumper/sticker/migrate/__testfixtures__/colorRenames.input.js
@@ -1,0 +1,13 @@
+import { Sticker } from '@ornikar/kitt-universal';
+
+function Example() {
+  return (
+    <>
+      <Sticker label="A" color="darkGreen" />
+      <Sticker label="B" color="darkBlue" />
+      <Sticker label="C" color="promo" />
+      <Sticker label="D" color="darkPromo" />
+      <Sticker label="E" color="linen" />
+    </>
+  );
+}

--- a/lib/codemods/bumper/sticker/migrate/__testfixtures__/colorRenames.output.js
+++ b/lib/codemods/bumper/sticker/migrate/__testfixtures__/colorRenames.output.js
@@ -1,0 +1,13 @@
+import { Sticker } from '@ornikar/bumper';
+
+function Example() {
+  return (
+    <>
+      <Sticker label="A" color="greenDark" />
+      <Sticker label="B" color="blueDark" />
+      <Sticker label="C" color="lightning" />
+      <Sticker label="D" color="lightningDark" />
+      <Sticker label="E" color="linen" />
+    </>
+  );
+}

--- a/lib/codemods/bumper/sticker/migrate/__testfixtures__/colorRenames.output.js
+++ b/lib/codemods/bumper/sticker/migrate/__testfixtures__/colorRenames.output.js
@@ -3,11 +3,11 @@ import { Sticker } from '@ornikar/bumper';
 function Example() {
   return (
     <>
-      <Sticker label="A" color="greenDark" />
-      <Sticker label="B" color="blueDark" />
-      <Sticker label="C" color="lightning" />
-      <Sticker label="D" color="lightningDark" />
-      <Sticker label="E" color="linen" />
+      <Sticker label="A" stickerColor="greenDark" />
+      <Sticker label="B" stickerColor="blueDark" />
+      <Sticker label="C" stickerColor="lightning" />
+      <Sticker label="D" stickerColor="lightningDark" />
+      <Sticker label="E" stickerColor="linen" />
     </>
   );
 }

--- a/lib/codemods/bumper/sticker/migrate/__testfixtures__/combined.input.js
+++ b/lib/codemods/bumper/sticker/migrate/__testfixtures__/combined.input.js
@@ -1,0 +1,15 @@
+import { Sticker, StickerColor, Typography } from '@ornikar/kitt-universal';
+
+function A({ state }) {
+  return <Sticker label="x" color={state === 'off' ? 'disabled' : 'darkGreen'} size="medium" />;
+}
+
+function B() {
+  return <Sticker label="y" color="promo" stretch />;
+}
+
+function C({ c }) {
+  return <Sticker label="z" color={c} />;
+}
+
+export { StickerColor };

--- a/lib/codemods/bumper/sticker/migrate/__testfixtures__/combined.output.js
+++ b/lib/codemods/bumper/sticker/migrate/__testfixtures__/combined.output.js
@@ -3,16 +3,16 @@ import { Typography } from '@ornikar/kitt-universal';
 import { Sticker, StickerColor } from '@ornikar/bumper';
 
 function A({ state }) {
-  return <Sticker label="x" disabled={state === 'off'} color="greenDark" size="medium" />;
+  return <Sticker label="x" disabled={state === 'off'} stickerColor="greenDark" size="medium" />;
 }
 
 // TODO: [Sticker migration] `stretch` has no bumper equivalent. Remove the prop or wrap in <View width='100%' alignItems='center'>.
 function B() {
-  return <Sticker label="y" color="lightning" stretch />;
+  return <Sticker label="y" stickerColor="lightning" stretch />;
 }
 
 function C({ c }) {
-  return <Sticker label="z" color={c} />;
+  return <Sticker label="z" stickerColor={c} />;
 }
 
 export { StickerColor };

--- a/lib/codemods/bumper/sticker/migrate/__testfixtures__/combined.output.js
+++ b/lib/codemods/bumper/sticker/migrate/__testfixtures__/combined.output.js
@@ -1,0 +1,18 @@
+import { Typography } from '@ornikar/kitt-universal';
+
+import { Sticker, StickerColor } from '@ornikar/bumper';
+
+function A({ state }) {
+  return <Sticker label="x" disabled={state === 'off'} color="greenDark" size="medium" />;
+}
+
+// TODO: [Sticker migration] `stretch` has no bumper equivalent. Remove the prop or wrap in <View width='100%' alignItems='center'>.
+function B() {
+  return <Sticker label="y" color="lightning" stretch />;
+}
+
+function C({ c }) {
+  return <Sticker label="z" color={c} />;
+}
+
+export { StickerColor };

--- a/lib/codemods/bumper/sticker/migrate/__testfixtures__/disabledColor.input.js
+++ b/lib/codemods/bumper/sticker/migrate/__testfixtures__/disabledColor.input.js
@@ -1,0 +1,5 @@
+import { Sticker } from '@ornikar/kitt-universal';
+
+function Example() {
+  return <Sticker label="Offline" color="disabled" />;
+}

--- a/lib/codemods/bumper/sticker/migrate/__testfixtures__/disabledColor.output.js
+++ b/lib/codemods/bumper/sticker/migrate/__testfixtures__/disabledColor.output.js
@@ -1,0 +1,5 @@
+import { Sticker } from '@ornikar/bumper';
+
+function Example() {
+  return <Sticker label="Offline" disabled />;
+}

--- a/lib/codemods/bumper/sticker/migrate/__testfixtures__/disabledConditional.input.js
+++ b/lib/codemods/bumper/sticker/migrate/__testfixtures__/disabledConditional.input.js
@@ -1,0 +1,9 @@
+import { Sticker } from '@ornikar/kitt-universal';
+
+function A({ isInactive }) {
+  return <Sticker label="Item" color={isInactive ? 'disabled' : 'green'} />;
+}
+
+function B({ isActive }) {
+  return <Sticker label="Item" color={isActive ? 'darkGreen' : 'disabled'} />;
+}

--- a/lib/codemods/bumper/sticker/migrate/__testfixtures__/disabledConditional.output.js
+++ b/lib/codemods/bumper/sticker/migrate/__testfixtures__/disabledConditional.output.js
@@ -1,0 +1,9 @@
+import { Sticker } from '@ornikar/bumper';
+
+function A({ isInactive }) {
+  return <Sticker label="Item" disabled={isInactive} color="green" />;
+}
+
+function B({ isActive }) {
+  return <Sticker label="Item" disabled={!isActive} color="greenDark" />;
+}

--- a/lib/codemods/bumper/sticker/migrate/__testfixtures__/disabledConditional.output.js
+++ b/lib/codemods/bumper/sticker/migrate/__testfixtures__/disabledConditional.output.js
@@ -1,9 +1,9 @@
 import { Sticker } from '@ornikar/bumper';
 
 function A({ isInactive }) {
-  return <Sticker label="Item" disabled={isInactive} color="green" />;
+  return <Sticker label="Item" disabled={isInactive} stickerColor="green" />;
 }
 
 function B({ isActive }) {
-  return <Sticker label="Item" disabled={!isActive} color="greenDark" />;
+  return <Sticker label="Item" disabled={!isActive} stickerColor="greenDark" />;
 }

--- a/lib/codemods/bumper/sticker/migrate/__testfixtures__/dynamicColorExpression.input.js
+++ b/lib/codemods/bumper/sticker/migrate/__testfixtures__/dynamicColorExpression.input.js
@@ -1,0 +1,16 @@
+import { Sticker } from '@ornikar/kitt-universal';
+
+function Ternary({ theme }) {
+  return <Sticker label="x" color={theme === 'dark' ? 'darkGreen' : 'green'} />;
+}
+
+function LookupTable({ kind, label }) {
+  const colorMap = {
+    success: 'green',
+    warning: 'gold',
+    error: 'red',
+    paused: 'darkBlue',
+    pro: 'promo',
+  };
+  return <Sticker label={label} color={colorMap[kind]} />;
+}

--- a/lib/codemods/bumper/sticker/migrate/__testfixtures__/dynamicColorExpression.output.js
+++ b/lib/codemods/bumper/sticker/migrate/__testfixtures__/dynamicColorExpression.output.js
@@ -1,7 +1,7 @@
 import { Sticker } from '@ornikar/bumper';
 
 function Ternary({ theme }) {
-  return <Sticker label="x" color={theme === 'dark' ? 'greenDark' : 'green'} />;
+  return <Sticker label="x" stickerColor={theme === 'dark' ? 'greenDark' : 'green'} />;
 }
 
 function LookupTable({ kind, label }) {
@@ -12,5 +12,5 @@ function LookupTable({ kind, label }) {
     paused: 'darkBlue',
     pro: 'promo',
   };
-  return <Sticker label={label} color={colorMap[kind]} />;
+  return <Sticker label={label} stickerColor={colorMap[kind]} />;
 }

--- a/lib/codemods/bumper/sticker/migrate/__testfixtures__/dynamicColorExpression.output.js
+++ b/lib/codemods/bumper/sticker/migrate/__testfixtures__/dynamicColorExpression.output.js
@@ -1,0 +1,16 @@
+import { Sticker } from '@ornikar/bumper';
+
+function Ternary({ theme }) {
+  return <Sticker label="x" color={theme === 'dark' ? 'greenDark' : 'green'} />;
+}
+
+function LookupTable({ kind, label }) {
+  const colorMap = {
+    success: 'green',
+    warning: 'gold',
+    error: 'red',
+    paused: 'darkBlue',
+    pro: 'promo',
+  };
+  return <Sticker label={label} color={colorMap[kind]} />;
+}

--- a/lib/codemods/bumper/sticker/migrate/__testfixtures__/imports.input.js
+++ b/lib/codemods/bumper/sticker/migrate/__testfixtures__/imports.input.js
@@ -1,0 +1,7 @@
+import { Sticker, StickerProps, StickerColor, Typography } from '@ornikar/kitt-universal';
+
+function Example({ color }) {
+  return <Sticker label="x" color={color} />;
+}
+
+export { StickerProps, StickerColor };

--- a/lib/codemods/bumper/sticker/migrate/__testfixtures__/imports.output.js
+++ b/lib/codemods/bumper/sticker/migrate/__testfixtures__/imports.output.js
@@ -1,0 +1,9 @@
+import { Typography } from '@ornikar/kitt-universal';
+
+import { Sticker, StickerProps, StickerColor } from '@ornikar/bumper';
+
+function Example({ color }) {
+  return <Sticker label="x" color={color} />;
+}
+
+export { StickerProps, StickerColor };

--- a/lib/codemods/bumper/sticker/migrate/__testfixtures__/imports.output.js
+++ b/lib/codemods/bumper/sticker/migrate/__testfixtures__/imports.output.js
@@ -3,7 +3,7 @@ import { Typography } from '@ornikar/kitt-universal';
 import { Sticker, StickerProps, StickerColor } from '@ornikar/bumper';
 
 function Example({ color }) {
-  return <Sticker label="x" color={color} />;
+  return <Sticker label="x" stickerColor={color} />;
 }
 
 export { StickerProps, StickerColor };

--- a/lib/codemods/bumper/sticker/migrate/__testfixtures__/stretchProp.input.js
+++ b/lib/codemods/bumper/sticker/migrate/__testfixtures__/stretchProp.input.js
@@ -1,0 +1,9 @@
+import { Sticker } from '@ornikar/kitt-universal';
+
+function Stretched() {
+  return <Sticker label="Full" color="green" stretch />;
+}
+
+function NotStretched() {
+  return <Sticker label="Narrow" color="green" stretch={false} />;
+}

--- a/lib/codemods/bumper/sticker/migrate/__testfixtures__/stretchProp.output.js
+++ b/lib/codemods/bumper/sticker/migrate/__testfixtures__/stretchProp.output.js
@@ -2,9 +2,9 @@ import { Sticker } from '@ornikar/bumper';
 
 // TODO: [Sticker migration] `stretch` has no bumper equivalent. Remove the prop or wrap in <View width='100%' alignItems='center'>.
 function Stretched() {
-  return <Sticker label="Full" color="green" stretch />;
+  return <Sticker label="Full" stickerColor="green" stretch />;
 }
 
 function NotStretched() {
-  return <Sticker label="Narrow" color="green" />;
+  return <Sticker label="Narrow" stickerColor="green" />;
 }

--- a/lib/codemods/bumper/sticker/migrate/__testfixtures__/stretchProp.output.js
+++ b/lib/codemods/bumper/sticker/migrate/__testfixtures__/stretchProp.output.js
@@ -1,0 +1,10 @@
+import { Sticker } from '@ornikar/bumper';
+
+// TODO: [Sticker migration] `stretch` has no bumper equivalent. Remove the prop or wrap in <View width='100%' alignItems='center'>.
+function Stretched() {
+  return <Sticker label="Full" color="green" stretch />;
+}
+
+function NotStretched() {
+  return <Sticker label="Narrow" color="green" />;
+}

--- a/lib/codemods/bumper/sticker/migrate/__tests__/index.test.js
+++ b/lib/codemods/bumper/sticker/migrate/__tests__/index.test.js
@@ -1,0 +1,20 @@
+'use strict';
+
+jest.autoMockOff();
+const { defineTest } = require('jscodeshift/dist/testUtils');
+
+const tests = [
+  'basic',
+  'imports',
+  'colorRenames',
+  'disabledColor',
+  'disabledConditional',
+  'dynamicColorExpression',
+  'stretchProp',
+  'alreadyBumper',
+  'combined',
+];
+
+describe('Sticker migration (kitt-universal → bumper)', () => {
+  tests.forEach((test) => defineTest(__dirname, 'index', null, test));
+});

--- a/lib/codemods/bumper/sticker/migrate/index.js
+++ b/lib/codemods/bumper/sticker/migrate/index.js
@@ -3,10 +3,11 @@
 /**
  * Migrates Sticker components from @ornikar/kitt-universal to @ornikar/bumper.
  *
- * Handles: import updates, color value renames (darkGreen → greenDark,
- * darkBlue → blueDark, promo → lightning, darkPromo → lightningDark),
- * `color="disabled"` → `disabled` boolean prop (including ternary extraction),
- * and TODO flagging for `stretch` (no bumper equivalent).
+ * Handles: import updates, `color` → `stickerColor` prop rename, color value
+ * renames (darkGreen → greenDark, darkBlue → blueDark, promo → lightning,
+ * darkPromo → lightningDark), `color="disabled"` → `disabled` boolean prop
+ * (including ternary extraction), and TODO flagging for `stretch` (no bumper
+ * equivalent).
  */
 
 const jscodeshift = require('jscodeshift');
@@ -149,14 +150,18 @@ module.exports = async function transformer(fileInfo, api) {
 
       // --- color ---
       if (propName === 'color') {
-        // color="xxx"
+        // color="disabled" → drop, add bare `disabled`
         const literalValue = stringLiteralValue(attr.value);
+        if (literalValue === 'disabled') {
+          newAttrs.push(j.jsxAttribute(j.jsxIdentifier('disabled')));
+          continue;
+        }
+
+        // All remaining cases keep a value-bearing prop, renamed to `stickerColor`.
+        attr.name = j.jsxIdentifier('stickerColor');
+
+        // color="xxx"
         if (literalValue !== null) {
-          if (literalValue === 'disabled') {
-            // Drop color, add bare `disabled`
-            newAttrs.push(j.jsxAttribute(j.jsxIdentifier('disabled')));
-            continue;
-          }
           const renamed = COLOR_RENAME_MAP[literalValue];
           if (renamed) {
             attr.value = j.stringLiteral(renamed);
@@ -175,7 +180,7 @@ module.exports = async function transformer(fileInfo, api) {
             const altValue = stringLiteralValue(expr.alternate);
 
             if (consValue === 'disabled' && altValue !== 'disabled') {
-              // disabled branch in consequent → disabled={test}, color={alternate}
+              // disabled branch in consequent → disabled={test}, stickerColor={alternate}
               newAttrs.push(j.jsxAttribute(j.jsxIdentifier('disabled'), j.jsxExpressionContainer(expr.test)));
               renameColorLiteralsDeep(expr.alternate);
               attr.value = isStringLiteralNode(expr.alternate)
@@ -185,7 +190,7 @@ module.exports = async function transformer(fileInfo, api) {
               continue;
             }
             if (altValue === 'disabled' && consValue !== 'disabled') {
-              // disabled branch in alternate → disabled={!test}, color={consequent}
+              // disabled branch in alternate → disabled={!test}, stickerColor={consequent}
               newAttrs.push(
                 j.jsxAttribute(
                   j.jsxIdentifier('disabled'),

--- a/lib/codemods/bumper/sticker/migrate/index.js
+++ b/lib/codemods/bumper/sticker/migrate/index.js
@@ -1,0 +1,293 @@
+'use strict';
+
+/**
+ * Migrates Sticker components from @ornikar/kitt-universal to @ornikar/bumper.
+ *
+ * Handles: import updates, color value renames (darkGreen → greenDark,
+ * darkBlue → blueDark, promo → lightning, darkPromo → lightningDark),
+ * `color="disabled"` → `disabled` boolean prop (including ternary extraction),
+ * and TODO flagging for `stretch` (no bumper equivalent).
+ */
+
+const jscodeshift = require('jscodeshift');
+const prettier = require('prettier');
+
+// --- Value mappings ---
+
+const COLOR_RENAME_MAP = {
+  darkGreen: 'greenDark',
+  darkBlue: 'blueDark',
+  promo: 'lightning',
+  darkPromo: 'lightningDark',
+};
+
+const STICKER_IMPORT_NAMES = new Set(['Sticker', 'StickerProps', 'StickerColor', 'StickerSize']);
+
+// --- Helpers ---
+
+function isStringLiteralNode(node) {
+  return node && (node.type === 'StringLiteral' || (node.type === 'Literal' && typeof node.value === 'string'));
+}
+
+function stringLiteralValue(node) {
+  return isStringLiteralNode(node) ? node.value : null;
+}
+
+function renameColorLiteralsDeep(node) {
+  if (!node || typeof node !== 'object') return;
+  if (isStringLiteralNode(node)) {
+    const mapped = COLOR_RENAME_MAP[node.value];
+    if (mapped) node.value = mapped;
+    return;
+  }
+  for (const key of Object.keys(node)) {
+    if (key === 'loc' || key === 'start' || key === 'end' || key === 'range') continue;
+    const child = node[key];
+    if (Array.isArray(child)) {
+      child.forEach(renameColorLiteralsDeep);
+    } else if (child && typeof child === 'object') {
+      renameColorLiteralsDeep(child);
+    }
+  }
+}
+
+function isPlainSticker(openingElement, stickerLocalName) {
+  const name = openingElement.name;
+  return name.type === 'JSXIdentifier' && name.name === stickerLocalName;
+}
+
+function addStretchTodoComment(j, path) {
+  // Walk up until the containing top-level statement (direct child of Program).
+  // This places the TODO above the enclosing function declaration rather than
+  // inside the function body, matching the fixture expectations.
+  let current = path;
+  while (current.parent && current.parent.value.type !== 'Program') {
+    current = current.parent;
+  }
+  const targetNode = current.value;
+  if (!targetNode.comments) targetNode.comments = [];
+  const alreadyFlagged = targetNode.comments.some(
+    (c) => typeof c.value === 'string' && c.value.includes('Sticker migration'),
+  );
+  if (alreadyFlagged) return;
+  const comment = j.commentLine(
+    " TODO: [Sticker migration] `stretch` has no bumper equivalent. Remove the prop or wrap in <View width='100%' alignItems='center'>.",
+  );
+  comment.leading = true;
+  targetNode.comments.push(comment);
+}
+
+// --- Transformer ---
+
+module.exports = async function transformer(fileInfo, api) {
+  const j = api.jscodeshift || jscodeshift;
+  const root = j(fileInfo.source);
+
+  // ===== Step 0: Detect kitt-universal Sticker imports =====
+  const kittImports = root.find(j.ImportDeclaration, {
+    source: { value: '@ornikar/kitt-universal' },
+  });
+
+  let stickerLocalName = null;
+  const importedSpecifiers = { value: new Set(), type: new Set() };
+
+  kittImports.forEach((path) => {
+    const isTypeImport = path.value.importKind === 'type';
+    const bucket = isTypeImport ? importedSpecifiers.type : importedSpecifiers.value;
+    (path.value.specifiers || []).forEach((spec) => {
+      if (spec.type !== 'ImportSpecifier') return;
+      const imported = spec.imported.name;
+      if (!STICKER_IMPORT_NAMES.has(imported)) return;
+      bucket.add(imported);
+      if (imported === 'Sticker' && !stickerLocalName) {
+        stickerLocalName = spec.local ? spec.local.name : 'Sticker';
+      }
+    });
+  });
+
+  const hasAnyStickerImport = importedSpecifiers.value.size > 0 || importedSpecifiers.type.size > 0;
+  if (!hasAnyStickerImport) {
+    return fileInfo.source;
+  }
+
+  if (!stickerLocalName) stickerLocalName = 'Sticker';
+
+  let stickersTransformed = 0;
+
+  // ===== Step 1: Transform each <Sticker /> JSX element =====
+  root.find(j.JSXElement).forEach((path) => {
+    const element = path.value;
+    const openingElement = element.openingElement;
+    if (!isPlainSticker(openingElement, stickerLocalName)) return;
+
+    const newAttrs = [];
+    let hasStretchTodo = false;
+
+    for (const attr of openingElement.attributes) {
+      if (attr.type !== 'JSXAttribute') {
+        newAttrs.push(attr);
+        continue;
+      }
+      const propName = attr.name.name;
+
+      // --- stretch: flag for manual review, keep prop in place ---
+      if (propName === 'stretch') {
+        // stretch={false} is a no-op, safe to drop silently
+        if (attr.value && attr.value.type === 'JSXExpressionContainer') {
+          const expr = attr.value.expression;
+          if (
+            (expr.type === 'BooleanLiteral' && expr.value === false) ||
+            (expr.type === 'Literal' && expr.value === false)
+          ) {
+            continue;
+          }
+        }
+        hasStretchTodo = true;
+        newAttrs.push(attr);
+        continue;
+      }
+
+      // --- color ---
+      if (propName === 'color') {
+        // color="xxx"
+        const literalValue = stringLiteralValue(attr.value);
+        if (literalValue !== null) {
+          if (literalValue === 'disabled') {
+            // Drop color, add bare `disabled`
+            newAttrs.push(j.jsxAttribute(j.jsxIdentifier('disabled')));
+            continue;
+          }
+          const renamed = COLOR_RENAME_MAP[literalValue];
+          if (renamed) {
+            attr.value = j.stringLiteral(renamed);
+          }
+          newAttrs.push(attr);
+          continue;
+        }
+
+        // color={expr}
+        if (attr.value && attr.value.type === 'JSXExpressionContainer') {
+          const expr = attr.value.expression;
+
+          // color={ternary} with one branch === 'disabled'
+          if (expr.type === 'ConditionalExpression') {
+            const consValue = stringLiteralValue(expr.consequent);
+            const altValue = stringLiteralValue(expr.alternate);
+
+            if (consValue === 'disabled' && altValue !== 'disabled') {
+              // disabled branch in consequent → disabled={test}, color={alternate}
+              newAttrs.push(j.jsxAttribute(j.jsxIdentifier('disabled'), j.jsxExpressionContainer(expr.test)));
+              renameColorLiteralsDeep(expr.alternate);
+              attr.value = isStringLiteralNode(expr.alternate)
+                ? j.stringLiteral(expr.alternate.value)
+                : j.jsxExpressionContainer(expr.alternate);
+              newAttrs.push(attr);
+              continue;
+            }
+            if (altValue === 'disabled' && consValue !== 'disabled') {
+              // disabled branch in alternate → disabled={!test}, color={consequent}
+              newAttrs.push(
+                j.jsxAttribute(
+                  j.jsxIdentifier('disabled'),
+                  j.jsxExpressionContainer(j.unaryExpression('!', expr.test)),
+                ),
+              );
+              renameColorLiteralsDeep(expr.consequent);
+              attr.value = isStringLiteralNode(expr.consequent)
+                ? j.stringLiteral(expr.consequent.value)
+                : j.jsxExpressionContainer(expr.consequent);
+              newAttrs.push(attr);
+              continue;
+            }
+          }
+
+          // Any other dynamic expression: recursively rename literal color values
+          renameColorLiteralsDeep(expr);
+          newAttrs.push(attr);
+          continue;
+        }
+
+        newAttrs.push(attr);
+        continue;
+      }
+
+      // Keep all other props as-is (label, size, disabled if already boolean, spread, etc.)
+      newAttrs.push(attr);
+    }
+
+    openingElement.attributes = newAttrs;
+    stickersTransformed++;
+
+    if (hasStretchTodo) {
+      addStretchTodoComment(j, path);
+    }
+  });
+
+  // ===== Step 2: Rewrite imports =====
+  // Even if no JSX elements were transformed (e.g. only types imported), we still swap imports.
+
+  const valueSpecifiers = Array.from(importedSpecifiers.value);
+  const typeSpecifiers = Array.from(importedSpecifiers.type);
+
+  function addSpecifiersToBumperImport(specifierNames, isTypeOnly) {
+    if (specifierNames.length === 0) return;
+
+    const bumperImports = root
+      .find(j.ImportDeclaration, { source: { value: '@ornikar/bumper' } })
+      .filter((p) =>
+        isTypeOnly ? p.value.importKind === 'type' : !p.value.importKind || p.value.importKind === 'value',
+      );
+
+    if (bumperImports.length > 0) {
+      const target = bumperImports.at(0).get();
+      for (const name of specifierNames) {
+        const already = (target.value.specifiers || []).some(
+          (s) => s.type === 'ImportSpecifier' && s.imported.name === name,
+        );
+        if (!already) {
+          target.value.specifiers.push(j.importSpecifier(j.identifier(name)));
+        }
+      }
+      return;
+    }
+
+    const newImport = j.importDeclaration(
+      specifierNames.map((name) => j.importSpecifier(j.identifier(name))),
+      j.literal('@ornikar/bumper'),
+    );
+    if (isTypeOnly) newImport.importKind = 'type';
+
+    const allKittImports = root.find(j.ImportDeclaration, { source: { value: '@ornikar/kitt-universal' } });
+    if (allKittImports.length > 0) {
+      allKittImports.at(allKittImports.length - 1).insertAfter(newImport);
+    } else {
+      const body = root.find(j.Program).get().value.body;
+      body.unshift(newImport);
+    }
+  }
+
+  // Insert type import first, then value import. Both use insertAfter(last-kitt-u),
+  // so the later insertion ends up positioned first → final order is value, then type.
+  addSpecifiersToBumperImport(typeSpecifiers, true);
+  addSpecifiersToBumperImport(valueSpecifiers, false);
+
+  // Remove Sticker-related specifiers from kitt-universal imports
+  root.find(j.ImportDeclaration, { source: { value: '@ornikar/kitt-universal' } }).forEach((path) => {
+    const remaining = (path.value.specifiers || []).filter(
+      (spec) => spec.type !== 'ImportSpecifier' || !STICKER_IMPORT_NAMES.has(spec.imported.name),
+    );
+    if (remaining.length > 0) {
+      path.value.specifiers = remaining;
+    } else {
+      j(path).remove();
+    }
+  });
+
+  const output = root.toSource({ quote: 'single' });
+  const prettierConfig = await prettier.resolveConfig(fileInfo.path);
+
+  return prettier.format(output, {
+    ...prettierConfig,
+    filepath: fileInfo.path,
+  });
+};


### PR DESCRIPTION
# Summary
- Adds a jscodeshift codemod to migrate Sticker from @ornikar/kitt-universal to @ornikar/bumper
- Handles import updates (value + type imports, aliased locals), color value renames (darkGreen → greenDark, darkBlue → blueDark, promo → lightning, darkPromo → lightningDark), color="disabled" extraction into a disabled boolean prop (including ternary branches like cond ? 'disabled' : 'green'), deep walking of dynamic color expressions, silent removal of stretch={false}, and TODO flagging above the enclosing function for any other form of stretch (no bumper equivalent)
- Includes 9 test fixtures covering all transformation scenarios

# Test plan

- [x] All 9 jscodeshift test fixtures pass (basic, imports, colorRenames, disabledColor, disabledConditional, dynamicColorExpression, stretchProp, alreadyBumper, combined)
- [ ] Tested on learner-apps (yornikar-migrate bumper/sticker/migrate "<scope>/**/*.{ts,tsx}") — diff reviewed, no false positives on colorMap-style external lookups

🤖 Generated with [Claude Code](https://claude.com/claude-code)